### PR TITLE
Libusb fixes for hamlib 4.3 and libusb-1.0.24

### DIFF
--- a/hamlib.sh
+++ b/hamlib.sh
@@ -11,10 +11,27 @@
 #        \/                   \/                        #
 #########################################################
 
-cd $DIR
+echo "#############################" 
+echo "# Install prereq libusb-1.0.24  #"
+echo "#############################"
+
+sudo apt-get install -y \
+  libasound2-dev \
+  cmake \
+  libudev-dev
+
+cd $HOME
 hamlib_DL=$(curl -sL https://api.github.com/repos/Hamlib/Hamlib/releases/latest | grep -o -m 1 "http.*tar.gz")
 hamlib_ver=$(echo $hamlib_DL | sed -nr '/.*\-(.{,10}).*/s//\1/p' | sed -n '/\.tar\.gz$/s///p')
-cd $HOME/Downloads
+
+echo "#############################" 
+echo "# Downloading libusb-1.0.24 #"
+echo "#############################"
+
+wget https://github.com/libusb/libusb/releases/download/v1.0.24/libusb-1.0.24.tar.bz2  -O - | tar -xj
+cd libusb-1.0.24
+./configure --prefix=/usr --disable-static && make
+sudo make install
 
 echo "######################" 
 echo "# Downloading hamlib #"
@@ -22,7 +39,6 @@ echo "######################"
 
 wget $hamlib_DL  -O - | tar -xz
 
-rm hamlib-$hamlib_ver.tar.gz
 cd hamlib-$hamlib_ver
 
 echo "######################" 


### PR DESCRIPTION
hamlib 4.3 now requires libusb 1.0.24 and it is not available for raspberry pi yet