### PR TITLE
Fix/trixie arm64 build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/ardop.sh
+++ b/ardop.sh
@@ -46,6 +46,7 @@ echo "#######################"
 echo "# ARDOP HF Entry      #"
 echo "#######################" 
 
+mkdir -p $HOME/.local/share/applications
 cat <<EOF > $HOME/.local/share/applications/ardopgui.desktop
 [Desktop Entry]
 Name=ARDOP GUI

--- a/chirp.sh
+++ b/chirp.sh
@@ -13,7 +13,8 @@
 #        \/                   \/                        #
 #########################################################
 
-cd $HOME/Downloads
+mkdir -p "$HOME/Downloads"
+cd "$HOME/Downloads"
 
 echo "#######################" 
 echo "# Downloading CHIRP #"

--- a/conky.sh
+++ b/conky.sh
@@ -12,7 +12,8 @@
 #        \/                   \/                        #
 #########################################################
 
-cd $HOME/Downloads
+mkdir -p "$HOME/Downloads"
+cd "$HOME/Downloads"
 
 echo "######################" 
 echo "# Read/Set CALLSIGN  #"

--- a/conky.sh
+++ b/conky.sh
@@ -70,6 +70,7 @@ echo "#######################"
 echo "# Desktop Entry       #"
 echo "#######################" 
 
+mkdir -p $HOME/.local/share/applications
 cat <<EOF > $HOME/.local/share/applications/conky.desktop
 [Desktop Entry]
 Name=Conky

--- a/conkySM.sh
+++ b/conkySM.sh
@@ -69,6 +69,7 @@ echo "#######################"
 echo "# Desktop Entry conky #"
 echo "#######################" 
 
+mkdir -p $HOME/.local/share/applications
 cat <<EOF > $HOME/.local/share/applications/conky.desktop
 [Desktop Entry]
 Name=Conky

--- a/conkySM.sh
+++ b/conkySM.sh
@@ -12,7 +12,8 @@
 #        \/                   \/                        #
 #########################################################
 
-cd $HOME/Downloads
+mkdir -p "$HOME/Downloads"
+cd "$HOME/Downloads"
 
 echo "######################" 
 echo "# Read/Set CALLSIGN  #"

--- a/direwolf_src.sh
+++ b/direwolf_src.sh
@@ -24,7 +24,7 @@ echo "#######################"
 echo "# Install  Direwolf   #"
 echo "#######################" 
 cd $HOME/direwolf
-mkdir build && cd build
+mkdir -p build && cd build
 cmake ..
 make -j 4
 sudo make install
@@ -34,7 +34,7 @@ echo "# Conf Direwolf       #"
 echo "#######################" 
 
 make install-conf
-sed -i "s/N0CALL/$CALL/" "$HOME/direwolf.conf"
+sed -i "s/N0CALL/$CALLSIGN/" "$HOME/direwolf.conf"
 sed -i 's/# ADEVICE  plughw:1,0/ADEVICE  plughw:2,0/' $HOME/direwolf.conf
 sed -i '/#PTT\ \/dev\/ttyUSB0\ RTS/a #Uncomment line below for PTT with sabrent sound card\n#PTT RIG 2 localhost:4532' $HOME/direwolf.conf
 rm -rf $HOME/direwolf

--- a/gpsTimeSync.sh
+++ b/gpsTimeSync.sh
@@ -12,7 +12,8 @@
 #        \/                   \/                        #
 #########################################################
 
-cd $HOME/Downloads
+mkdir -p "$HOME/Downloads"
+cd "$HOME/Downloads"
 
 echo "##############################" 
 echo "# Downloading GPSD & chrony  #"

--- a/install.sh
+++ b/install.sh
@@ -83,7 +83,7 @@ case $SELECTED in
         g++ \
         stow \
         extra-xdg-menus 
-    sudo pip3 install pi-ina219
+    sudo pip3 install pi-ina219 --break-system-packages 2>/dev/null || sudo pip3 install pi-ina219
     sudo sed -i "s/# en_US.UTF-8/en_US.UTF-8/g" /etc/locale.gen
     sudo locale-gen
 
@@ -92,58 +92,58 @@ case $SELECTED in
     sudo modprobe cp210x
 
 
-    sudo raspi-config nonint do_ssh
-    pcmanfm --set-wallpaper $HOME/baconTelegraph/files/radioRoom2.jpeg 
+    command -v raspi-config >/dev/null 2>&1 && sudo raspi-config nonint do_ssh
+    command -v pcmanfm >/dev/null 2>&1 && pcmanfm --set-wallpaper $HOME/baconTelegraph/files/radioRoom2.jpeg
 ;;
    "ALL") \
-/bin/sh $HOME/baconTelegraph/install_all.sh
+bash $HOME/baconTelegraph/install_all.sh
 ;;
    "hamlib") \
-/bin/sh $HOME/baconTelegraph/hamlib_src.sh
+bash $HOME/baconTelegraph/hamlib_src.sh
 ;;
    "JTDX") \
-/bin/sh $HOME/baconTelegraph/jtdx_src.sh
+bash $HOME/baconTelegraph/jtdx_src.sh
 ;;
    "WSJT-X") \
-/bin/sh $HOME/baconTelegraph/wsjtx_src.sh
+bash $HOME/baconTelegraph/wsjtx_src.sh
 ;;
    "CHIRP") \
-/bin/sh $HOME/baconTelegraph/chirp.sh
+bash $HOME/baconTelegraph/chirp.sh
 ;;
    "Conky") \
-/bin/sh $HOME/baconTelegraph/conky.sh
+bash $HOME/baconTelegraph/conky.sh
 ;;
    "ConkySM") \
-/bin/sh $HOME/baconTelegraph/conkySM.sh
+bash $HOME/baconTelegraph/conkySM.sh
 ;;
    "JS8Call") \
-/bin/sh $HOME/baconTelegraph/js8call_src.sh
+bash $HOME/baconTelegraph/js8call_src.sh
 ;;
    "wfview") \
-/bin/sh $HOME/baconTelegraph/wfview_src.sh
+bash $HOME/baconTelegraph/wfview_src.sh
 ;;
    "QSSTV") \
-/bin/sh $HOME/baconTelegraph/qsstv_src.sh
+bash $HOME/baconTelegraph/qsstv_src.sh
 ;;
    "ARDOP") \
-/bin/sh $HOME/baconTelegraph/ardop.sh
+bash $HOME/baconTelegraph/ardop.sh
 ;;
    "Direwolf") \
-/bin/sh $HOME/baconTelegraph/direwolf_src.sh
+bash $HOME/baconTelegraph/direwolf_src.sh
 ;;
    "XASTIR") \
-/bin/sh $HOME/baconTelegraph/xastir_src.sh
+bash $HOME/baconTelegraph/xastir_src.sh
 ;;
    "OP25") \
-/bin/sh $HOME/baconTelegraph/op25_src.sh
+bash $HOME/baconTelegraph/op25_src.sh
 ;;
    "gpsTimeSync") \
-/bin/sh $HOME/baconTelegraph/gpsTimeSync.sh
+bash $HOME/baconTelegraph/gpsTimeSync.sh
 ;;
    *) \
 echo "Sorry, no selection made"
-exit 0   
+exit 0
    ;;
 esac
 ####Once More
-/bin/sh install.sh
+bash $HOME/baconTelegraph/install.sh

--- a/install_all.sh
+++ b/install_all.sh
@@ -34,6 +34,6 @@ while IFS=: read -r f1 f2 f3; do
 
 	sleep 1
 
-done<app.list
+done<"$HOME/baconTelegraph/app.list"
 
 echo "FIN"

--- a/js8call_src.sh
+++ b/js8call_src.sh
@@ -51,7 +51,8 @@ sudo apt install -y \
 	libqt5multimedia5-plugins \
 	qtmultimedia5-dev \
 	libboost-dev \
-	libboost-all-dev
+	libboost-all-dev \
+	libboost1.81-all-dev
 
 sudo mkdir -p "$js8_stow"js8call
 

--- a/js8call_src.sh
+++ b/js8call_src.sh
@@ -14,7 +14,7 @@
 #########################################################
 
 
-mkdir $HOME/Downloads/js8call
+mkdir -p $HOME/Downloads/js8call
 
 echo "###################################################" 
 echo "# Downloading JS8Call Source                      #"

--- a/js8call_src.sh
+++ b/js8call_src.sh
@@ -42,16 +42,10 @@ sudo apt install -y \
   	asciidoctor \
 	texinfo \
   	libfftw3-dev \
-  	qtmultimedia5-dev \
-  	qttools5-dev \
-  	qttools5-dev-tools \
-  	libqt5serialport5-dev \
-	libqt5websockets5-dev \
-	libqt5multimedia5 \
-	libqt5multimedia5-plugins \
-	qtmultimedia5-dev \
-	libboost-dev \
-	libboost-all-dev \
+	qt6-base-dev \
+	qt6-multimedia-dev \
+	qt6-serialport-dev \
+	qt6-tools-dev \
 	libboost1.81-all-dev
 
 sudo mkdir -p "$js8_stow"js8call

--- a/js8call_src.sh
+++ b/js8call_src.sh
@@ -22,20 +22,14 @@ echo "###################################################"
 
 cd $HOME/Downloads/js8call
 
-js8_dl=$(curl -s http://files.js8call.com/latest.html | \
-    tac | \
-    grep .tgz | \
-    grep -v rc | \
-    awk -F'"' '$0=$2'
-)
-
-js8_ver="$(basename "$js8_dl" .tgz)"
+js8_tag=$(curl -s https://api.github.com/repos/js8call/js8call/releases/latest | grep -oP '"tag_name": ?"\K[^"]+')
+js8_ver="${js8_tag#v}"
 js8_stow="/usr/local/stow/"
 js8_BLD="js8call_BLD_DIR"
 
-wget -t 5 $js8_dl -O - | tar -xz
+wget -t 5 "https://github.com/js8call/js8call/archive/refs/tags/${js8_tag}.tar.gz" -O - | tar -xz
 
-mkdir $js8_BLD
+mkdir -p $js8_BLD
 
 
 echo "###################################################"
@@ -59,18 +53,17 @@ sudo apt install -y \
 	libboost-dev \
 	libboost-all-dev
 
-sudo mkdir "$js8_stow"js8call
+sudo mkdir -p "$js8_stow"js8call
 
 echo "###################################################"
 echo "# Installing JS8call in stow to remove run:       #"
 echo "# 'cd /usr/local/stow/ && sudo stow -D js8call'   #"
 echo "###################################################"
 
-cmake -DWSJT_GENERATE_DOCS=OFF -DWSJT_SKIP_MANPAGES=ON js8call
-cd $js8_BLD && cmake "../js8call"
+cd $js8_BLD && cmake -DWSJT_GENERATE_DOCS=OFF -DWSJT_SKIP_MANPAGES=ON "../js8call-$js8_ver"
 cd $HOME/Downloads/js8call
 
-cmake --build js8call_BLD_DIR -j4
+cmake --build js8call_BLD_DIR -j$(nproc)
 cd $HOME/Downloads/js8call/$js8_BLD && sudo cmake --install . --prefix "$js8_stow"js8call
 
 cd /usr/local/stow/ && sudo stow js8call

--- a/jtdx_src.sh
+++ b/jtdx_src.sh
@@ -12,8 +12,9 @@
 #        \/                   \/                        #
 #########################################################
 
-cd $HOME/Downloads
-mkdir jtdx
+mkdir -p "$HOME/Downloads"
+cd "$HOME/Downloads"
+mkdir -p jtdx
 
 echo "###################################################" 
 echo "# Downloading JTDX Source                         #"
@@ -26,7 +27,7 @@ jtdx_dl=159
 wget https://github.com/jtdx-project/jtdx/archive/refs/tags/${jtdx_dl}.tar.gz -O - | tar -xz
 
 
-mkdir JTDX_BLD_DIR
+mkdir -p JTDX_BLD_DIR
 
 
 echo "###################################################"
@@ -49,7 +50,7 @@ sudo apt install -y \
 	libboost-dev \
 	libboost-all-dev
 
-sudo mkdir /usr/local/stow/jtdx_$jtdx_dl
+sudo mkdir -p /usr/local/stow/jtdx_$jtdx_dl
 
 echo "###################################################"
 echo "# Installing JTDX in stow to remove run:          #"
@@ -60,8 +61,8 @@ cd $HOME/Downloads/jtdx/JTDX_BLD_DIR
 cmake \
 	-DWSJT_GENERATE_DOCS=OFF \
 	-DWSJT_SKIP_MANPAGES=ON \
-	-D CMAKE_INSTALL_PREFIX=/usr/local/stow/jtdx_$jtdx_dl" \
-	../jtdx-${jtdx_dl}"
+	-D CMAKE_INSTALL_PREFIX="/usr/local/stow/jtdx_$jtdx_dl" \
+	"../jtdx-${jtdx_dl}"
 
 cmake --build ../JTDX_BLD_DIR -j$(nproc)
 

--- a/op25_src.sh
+++ b/op25_src.sh
@@ -34,6 +34,7 @@ sudo apt update && sudo apt upgrade -y
     libitpp-dev \
     libpcap-dev \
     liborc-dev \
+    libcppunit-dev \
     cmake \
     git \
     swig \

--- a/op25_src.sh
+++ b/op25_src.sh
@@ -16,7 +16,7 @@ echo "#########################"
 echo "# Enable deb-src        #"
 echo "#########################" 
 
- sed -e "s/^# deb/deb/g" /etc/apt/sources.list
+ sudo sed -i -e "s/^# deb/deb/g" /etc/apt/sources.list
 
 echo "#########################" 
 echo "# Download install OP25 #"
@@ -77,6 +77,6 @@ echo "# Create aliase for OP25 #"
 echo "##########################" 
 
 cat <<EOF > $HOME/.bash_aliases
-alias op25='bash /home/pi/op25/op25.sh'
+alias op25='bash $HOME/op25/op25.sh'
 EOF
 

--- a/qsstv_src.sh
+++ b/qsstv_src.sh
@@ -23,7 +23,7 @@ qsstv_ver="qsstv_9.5"
 
 qsstv_stow="/usr/local/stow/$qsstv_ver"
 
-sudo mkdir $qsstv_stow
+sudo mkdir -p $qsstv_stow
 
 sudo apt-get install -y \
     libfftw3-dev \
@@ -50,7 +50,7 @@ echo "# cd /usr/local/stow/&& sudo stow --delete QSSTV* #"
 echo "###################################################"
 
 cd QSSTV
-mkdir src/build
+mkdir -p src/build
 cd src/build
 
 qmake .. PREFIX=$qsstv_stow
@@ -60,8 +60,8 @@ sudo make install
 echo "########################" 
 echo "# Desktop Entry & Icon #"
 echo "########################" 
-sudo mkdir $qsstv_stow/share
-sudo mkdir $qsstv_stow/share/applications
+sudo mkdir -p $qsstv_stow/share
+sudo mkdir -p $qsstv_stow/share/applications
 
 sudo dd of=$qsstv_stow/share/applications/qsstv.desktop << EOF
 [Desktop Entry]
@@ -75,6 +75,7 @@ Terminal=false
 Categories=HamRadio;
 EOF
 
+mkdir -p $HOME/.local/share/icons
 cp $HOME/Downloads/QSSTV/src/icons/qsstv.png $HOME/.local/share/icons/
 
 echo "###################################################"

--- a/qsstv_src.sh
+++ b/qsstv_src.sh
@@ -12,7 +12,8 @@
 #        \/                   \/                        #
 #########################################################
 
-cd $HOME/Downloads
+mkdir -p "$HOME/Downloads"
+cd "$HOME/Downloads"
 
 echo "###################################################"
 echo "# Prepping QSSTV build & prereqs                  #"

--- a/wfview_src.sh
+++ b/wfview_src.sh
@@ -24,7 +24,7 @@ wfview_ver=$(curl -s https://gitlab.com/api/v4/projects/9269387/releases/ | \
 
 wfview_stow="/usr/local/stow/$wfview_ver"
 
-sudo mkdir $wfview_stow
+sudo mkdir -p $wfview_stow
 
 sudo apt-get install -y \
     build-essential \
@@ -37,6 +37,7 @@ sudo apt-get install -y \
     libqt5multimedia5-plugins \
     qtmultimedia5-dev \
     git \
+    jq \
     libopus-dev \
     libeigen3-dev \
     portaudio19-dev \
@@ -46,17 +47,17 @@ sudo apt-get install -y \
 
 
 sudo apt-get install -y \
-    libqcustomplot2.0 \
+    libqcustomplot2.1 \
     libqcustomplot-doc \
     libqcustomplot-dev
 
 
 
-mkdir $HOME/Downloads/wfview
+mkdir -p $HOME/Downloads/wfview
 cd $HOME/Downloads
 git clone https://gitlab.com/eliggett/wfview.git
 cd wfview
-mkdir build
+mkdir -p build
 cd build
 qmake ../wfview.pro PREFIX=$wfview_stow
 make -j$(nproc)

--- a/wfview_src.sh
+++ b/wfview_src.sh
@@ -12,7 +12,8 @@
 #        \/                   \/                        #
 #########################################################
 
-cd $HOME/Downloads
+mkdir -p "$HOME/Downloads"
+cd "$HOME/Downloads"
 
 wfview_ver=$(curl -s https://gitlab.com/api/v4/projects/9269387/releases/ | \
     jq '.[]' | \

--- a/wfview_src.sh
+++ b/wfview_src.sh
@@ -15,16 +15,11 @@
 mkdir -p "$HOME/Downloads"
 cd "$HOME/Downloads"
 
-wfview_ver=$(curl -s https://gitlab.com/api/v4/projects/9269387/releases/ | \
-    jq '.[]' | \
-    jq -r '.name' | \
-    head -1 | \
-    sed -e 's/ v/_/g'
-)
+wfview_ver=$(curl -s https://gitlab.com/api/v4/projects/9269387/releases/ | jq -r '.[0].tag_name' | sed -e 's/^v//')
 
-wfview_stow="/usr/local/stow/$wfview_ver"
+wfview_stow="/usr/local/stow/wfview_$wfview_ver"
 
-sudo mkdir -p $wfview_stow
+sudo mkdir -p "$wfview_stow"
 
 sudo apt-get install -y \
     build-essential \
@@ -59,11 +54,11 @@ git clone https://gitlab.com/eliggett/wfview.git
 cd wfview
 mkdir -p build
 cd build
-qmake ../wfview.pro PREFIX=$wfview_stow
+qmake ../wfview.pro PREFIX="$wfview_stow"
 make -j$(nproc)
 sudo make install
 
 
-cd $wfview_stow/.. && sudo stow "$wfview_ver"
+cd "$wfview_stow/.." && sudo stow "wfview_$wfview_ver"
 
 sudo usermod -aG dialout $USER

--- a/wsjtx_src.sh
+++ b/wsjtx_src.sh
@@ -20,8 +20,7 @@ echo "# Downloading WSJT-X Source                       #"
 echo "###################################################" 
 
 wsjtx_ver=$(curl -qsL "https://sourceforge.net/projects/wsjt/best_release.json" | \
-	sed "s/, /,\n/g" | \
-	sed -rn "/release/,/\}/{ /filename/{ 0,//s/([^0-9]*)([0-9\.]+)([^0-9]*.*)/\2/ p }}"
+	grep -oP '"filename": ?"/wsjtx-\K[0-9][^/"]*' | head -1
 	)
 
 wsjtx_stow="/usr/local/stow/wsjtx_"$wsjtx_ver""

--- a/wsjtx_src.sh
+++ b/wsjtx_src.sh
@@ -13,7 +13,7 @@
 #        \/                   \/                        #
 #########################################################
 
-mkdir $HOME/Downloads/wsjtx
+mkdir -p $HOME/Downloads/wsjtx
 
 echo "###################################################" 
 echo "# Downloading WSJT-X Source                       #"

--- a/xastir_src.sh
+++ b/xastir_src.sh
@@ -89,6 +89,7 @@ echo "# Stowing XASTIR to remove run                     #"
 echo "# cd /usr/local/stow/&& sudo stow --delete xastir* #"
 echo "####################################################"
 
+mkdir -p $HOME/.local/share/icons
 cp $HOME/Downloads/Xastir/symbols/icon.png $HOME/.local/share/icons/
 
 mv $HOME/.local/share/icons/icon.png $HOME/.local/share/icons/xastir.png

--- a/xastir_src.sh
+++ b/xastir_src.sh
@@ -12,7 +12,8 @@
 #        \/                   \/                        #
 #########################################################
 
-cd $HOME/Downloads
+mkdir -p "$HOME/Downloads"
+cd "$HOME/Downloads"
 
 echo "###################################################"
 echo "# Prepping XASTIR build & prereqs                 #"


### PR DESCRIPTION
## Summary

Mike (@desmando) and Claude paired on this: worked through installing baconTelegraph end-to-end on a fresh arm64 VPS and on a real Raspberry Pi, fixing every real failure hit along the way rather than guessing at fixes in the abstract. Resolves the errors reported in #11 ("Errors on fresh install") plus several more that only surface once you get past that point.

Every fix below was verified by actually running the affected script and observing success, not just read for plausibility.

## What's fixed

**The #11 crash (dash vs bash + relative paths)**
`install.sh` invoked every sub-script — including itself and `install_all.sh` — via `/bin/sh` instead of `bash`. `install_all.sh` uses `typeset`, a bash-only builtin that dash doesn't have, and both `install.sh`'s self-relaunch and `install_all.sh`'s `app.list` read used relative paths that only worked if you happened to already be sitting in `~/baconTelegraph`. Switched every invocation to `bash` with absolute paths.

**PEP 668 (`externally-managed-environment`)**
`pip3 install pi-ina219` now tries `--break-system-packages` first, falling back cleanly on older OS versions where that flag doesn't exist.

**Missing XDG directories on non-desktop installs**
Raspberry Pi Desktop pre-creates `~/Downloads`, `~/.local/share/icons`, and `~/.local/share/applications` via `xdg-user-dirs`. Headless installs (Pi OS Lite, or any generic Debian box) don't have them, and since none of these scripts use `set -e`, a failed `cd`/`mkdir` was silently swallowed — every following command in the script then ran wherever the shell actually was, in one case dumping WSJT-X's entire build tree inside the `baconTelegraph` repo checkout itself. Added `mkdir -p` everywhere this was assumed, across `wsjtx_src.sh`, `jtdx_src.sh`, `js8call_src.sh`, `qsstv_src.sh`, `wfview_src.sh`, `xastir_src.sh`, `chirp.sh`, `conky.sh`, `conkySM.sh`, `gpsTimeSync.sh`, and `ardop.sh`.

**WSJT-X version parsing**
SourceForge's `best_release.json` currently points at a `-rc1` prerelease; the old sed pipeline stripped everything but `[0-9.]`, silently truncating to a version that doesn't exist and 404ing the download. Now parses the version straight out of the `filename` field, suffix and all.

**Direwolf writing a blank callsign**
`direwolf_src.sh` referenced `$CALL`, which is never set anywhere — `install.sh` exports `$CALLSIGN`. The `sed` still matched the placeholder in the generated conf, so it silently substituted in an empty string, leaving `MYCALL` blank in `direwolf.conf`.

**JS8Call: dead upstream + version bumps**
`files.js8call.com`'s TLS certificate has expired, so the version scrape returned nothing and the build never started. Switched to the official `js8call/js8call` GitHub mirror. Along the way, current JS8Call also requires Boost ≥1.77 (Debian 12's default is 1.74 — added `libboost1.81-all-dev`, which Debian ships side by side) and has fully migrated to Qt6 (`find_package(Qt6 6.4 REQUIRED ...)`, no Qt5 fallback), so swapped the apt list to the Qt6 dev packages.

**wfview: nonexistent package + version string**
Requested `libqcustomplot2.0`, which doesn't exist on Debian 12 (only `2.1` does) — since one bad package name fails the whole `apt install` line, `libqcustomplot-dev` silently never installed either, and the build died later on a missing header with no obvious link back to the cause. Separately, GitLab's release name is `"Version 2.11"` (capital V, with a space); the script's sed only matched lowercase `" v"`, so the space survived into every unquoted use of the version string and the final `stow` step died with `cd: too many arguments`. Switched to the release's `tag_name` (`v2.11`) instead, and quoted every remaining expansion.

**JTDX cmake quoting**
A stray quote merged `CMAKE_INSTALL_PREFIX` and the source directory into a single argument, so cmake configured against the wrong directory. Fixed the quoting.

**OP25**
The `sed` enabling `deb-src` was missing `-i`, so it printed the modified sources.list to stdout and never actually changed anything. The generated shell alias hardcoded `/home/pi`, breaking for any other username. And OP25's own `CMakeLists.txt` hard-requires CppUnit, which was never in the prereq list, so configure failed immediately after cloning.

**Windows line-ending safety net**
Added `.gitattributes` (`* text=auto eol=lf`) so a Windows checkout with `core.autocrlf=true` can't silently reintroduce CRLF into these scripts again — that bit us mid-session (a raw `scp` of a locally-edited file, bypassing git's normalization, briefly broke `wsjtx_src.sh` on the test box).

## Testing

- **arm64 VPS (Debian 12/bookworm):** every script above run to completion and its resulting binary verified to execute (`rigctl --version`, `wsjtx --version`, stow symlinks resolving correctly, etc).
- **Real Raspberry Pi (Model B+, armv6l/armhf, Raspbian 13/trixie):** hamlib, CHIRP, ARDOP, gpsTimeSync, Conky/ConkySM, Direwolf, and Xastir all confirmed building and running on the actual target hardware. The Qt5/Qt6+Boost apps (WSJT-X, JTDX, JS8Call, QSSTV, wfview) and OP25/GNU Radio were intentionally left untested on this specific board — a single 700MHz ARM11 core with 437MB RAM isn't a realistic target for those regardless of script correctness.

No functional/feature changes — this is purely getting the existing install flow working again on current OS releases.
